### PR TITLE
Use ruby 2.3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby "2.2.4"
+ruby "2.3.0"
 
 # Distribute your app as a gem
 # gemspec

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 # https://circleci.com/docs/config-sample
 machine:
   ruby:
-    version: 2.2.4
+    version: 2.3.0
 
   services:
     - memcached


### PR DESCRIPTION
https://circleci.com/gh/sue445/sebastian-badge/267

Hmmm...

```
remote: bundle exec ruby groonga/init.rb
remote: /app/vendor/bundle/ruby/2.3.0/gems/bundler-1.9.7/lib/bundler/definition.rb:379:in `validate_ruby!': Your Ruby version is 2.3.0, but your Gemfile specified 2.2.4 (Bundler::RubyVersionMismatch)
remote: 	from /app/vendor/bundle/ruby/2.3.0/gems/bundler-1.9.7/lib/bundler.rb:118:in `setup'
remote: 	from /app/vendor/bundle/ruby/2.3.0/gems/bundler-1.9.7/lib/bundler/setup.rb:18:in `<top (required)>'
remote: 	from /app/vendor/ruby-2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
remote: 	from /app/vendor/ruby-2.3.0/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
remote: 
remote:  !     Push rejected, failed to compile Rroonga app
remote: 
remote: Verifying deploy...
remote: 
remote: !	Push rejected to sebastian-badge.
remote: 
error: Could not read fbd00221caeaf81ca59738aa7d8d1122767b4456
fatal: Failed to traverse parents of commit 5d401c8f294dda6aa986b2adc66d12e61f2f7a05
error: failed to run repack
To git@heroku.com:sebastian-badge.git
 ! [remote rejected] 0354d798394f290a4f2d8ab597828dbca71f77b6 -> master (pre-receive hook declined)

```