### PR TITLE
Fix ArgumentError: unregistered Groonga object: name: <"UInt32">

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bundle exec rake groonga:setup && bundle exec puma -C config/puma.rb
+web: bundle exec puma -C config/puma.rb

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -8,6 +8,11 @@ rackup      DefaultRackup
 port        ENV["PORT"]     || 3000
 environment ENV["RACK_ENV"] || "development"
 
+before_fork do
+  result = system "rake groonga:setup"
+  raise "Failed: rake groonga:setup" unless result
+end
+
 on_worker_boot do
   # Worker specific setup for Rails 4.1+
   # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot

--- a/groonga/init.rb
+++ b/groonga/init.rb
@@ -1,1 +1,6 @@
-system "bundle exec rake groonga:setup"
+require "bundler"
+
+Bundler.with_clean_env do
+  result = system "bundle exec rake groonga:setup"
+  raise "Failed: rake groonga:setup" unless result
+end


### PR DESCRIPTION
`bundle exec rake groonga:setup ` is ok , but `bundle exec foreman s` is failed...

```sh
$ bundle exec foreman s
23:21:40 web.1  | started with pid 26580
23:21:42 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:51: warning: constant ::Fixnum is deprecated
23:21:42 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/activesupport-5.0.1/lib/active_support/xml_mini.rb:52: warning: constant ::Bignum is deprecated
23:21:42 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/sinatra-2.0.0.beta2/lib/sinatra/base.rb:1256: warning: constant ::Fixnum is deprecated
23:21:42 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/sinatra-2.0.0.beta2/lib/sinatra/base.rb:1256: warning: constant ::Fixnum is deprecated
23:21:42 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/sinatra-2.0.0.beta2/lib/sinatra/base.rb:1256: warning: constant ::Fixnum is deprecated
23:21:42 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/sinatra-2.0.0.beta2/lib/sinatra/base.rb:1256: warning: constant ::Fixnum is deprecated
23:21:43 web.1  | DEPRECATION WARNING: Kaminari Sinatra support has been extracted to a separate gem, and will be removed in the next 1.0 release. Please bundle kaminari-sinatra gem. (called from require at /Users/sue445/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/bundler-1.13.6/lib/bundler/runtime.rb:91)
23:21:44 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/sinatra-2.0.0.beta2/lib/sinatra/base.rb:1256: warning: constant ::Fixnum is deprecated
23:21:46 web.1  |    INFO -  Setup Groonga
23:21:46 web.1  | rake aborted!
23:21:46 web.1  | ArgumentError: unregistered Groonga object: name: <"UInt32">
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rroonga-6.1.0/lib/groonga/schema.rb:815:in `create'
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rroonga-6.1.0/lib/groonga/schema.rb:815:in `define'
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rroonga-6.1.0/lib/groonga/schema.rb:629:in `block in define'
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rroonga-6.1.0/lib/groonga/schema.rb:628:in `each'
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rroonga-6.1.0/lib/groonga/schema.rb:628:in `define'
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rroonga-6.1.0/lib/groonga/schema.rb:171:in `define'
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/lib/tasks/groonga.rake:9:in `block (2 levels) in <top (required)>'
23:21:46 web.1  | /Users/sue445/dev/workspace/github.com/sue445/sebastian-badge/vendor/bundle/ruby/2.4.0/gems/rake-11.3.0/exe/rake:27:in `<top (required)>'
23:21:46 web.1  | /Users/sue445/.rbenv/versions/2.4.0/bin/bundle:22:in `load'
23:21:46 web.1  | /Users/sue445/.rbenv/versions/2.4.0/bin/bundle:22:in `<main>'
23:21:46 web.1  | Tasks: TOP => groonga:setup
23:21:46 web.1  | (See full trace by running task with --trace)
23:21:47 web.1  | exited with code 1
23:21:47 system | sending SIGTERM to all processes
```

and error at https://circleci.com/gh/sue445/sebastian-badge/420