### PR TITLE
Rollback to `circleci/postgres`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
       - image: cimg/ruby:2.7.2
         environment:
           RACK_ENV: test
-      - image: cimg/postgres:9.6
+      - image: circleci/postgres:9.5-alpine-ram
         environment:
           POSTGRES_USER: ubuntu
           POSTGRES_DB: circle_test


### PR DESCRIPTION
`cimg/postgres` is broken...

```
server started
psql: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
LOG:  received SIGHUP, reloading configuration files
LOG:  parameter "listen_addresses" cannot be changed without restarting the server
LOG:  configuration file "/var/lib/postgresql/data/postgresql.conf" contains errors; unaffected changes were applied

Exited with code 2
```

https://app.circleci.com/pipelines/github/sue445/sebastian-badge/1458/workflows/90e3e3bd-654a-4591-8ed0-ee3d58be70b3/jobs/4947

ref https://github.com/CircleCI-Public/cimg-postgres/issues/21